### PR TITLE
Fix symbol for Indian rupee

### DIFF
--- a/packages/currencies-en/resources/data.csv
+++ b/packages/currencies-en/resources/data.csv
@@ -45,7 +45,7 @@ hrk,hrk,191,2,Croatian Kuna,Croatian kunas,0,kn,kn
 huf,huf,348,0,Hungarian Forint,Hungarian forints,0,Ft,Ft
 idr,idr,360,0,Indonesian Rupiah,Indonesian rupiahs,0,Rp,Rp
 ils,ils,376,2,Israeli New Sheqel,Israeli new sheqels,0,₪,₪
-inr,inr,356,2,Indian Rupee,Indian rupees,0,Rs,টকা
+inr,inr,356,2,Indian Rupee,Indian rupees,0,₹,₹
 iqd,iqd,368,0,Iraqi Dinar,Iraqi dinars,0,IQD,د.ع.‏
 irr,irr,364,0,Iranian Rial,Iranian rials,0,IRR,﷼
 isk,isk,352,0,Icelandic Króna,Icelandic krónur,0,Ikr,kr


### PR DESCRIPTION
Symbol for Indian rupee is wrong. 

Currently the symbol_native gives "taka" in Bengali language. symbol field has old symbol for the currency (Rs), which is officially discontinued as of 2010 (https://en.wikipedia.org/wiki/Indian_rupee_sign).